### PR TITLE
Added support for closing the pdf preview when hitting "back"

### DIFF
--- a/_assets/js/script.js
+++ b/_assets/js/script.js
@@ -8,13 +8,19 @@ $('.embed').click(function(e) {
 	// console.log(url);
 	loadPdfEmbed($this.text(), url, $this);
 	
+	history.pushState({embedUrl: url}, $this.text(), "?" + url.substr(url.lastIndexOf('/') + 1));
 	$('#embed').show();
 });
 
 $('#embed .embed-close').click(function(e) {
 	e.preventDefault();
+	history.back();
 	$('#embed').hide();
 });
+
+window.onpopstate = function(e) {
+	$('#embed').hide();
+};
 
 function loadPdfEmbed(title, url, $this) {
 	url = url || title;


### PR DESCRIPTION
* **Contributing guidelines check**
- [x] Check that this pull request follows our contributing guidelines

* **Are you adding new files?**
No.

* **Comment your changes:**

After opening the pdf preview of a file, you can either:
\- Hit the "x" icon; or
\- Hit return

Hitting return is especially handy on mobile devices, for which this website has been thought for.
So this is a great new feature. 👏 