### PR TITLE
pdfshrinker: added some logging

### DIFF
--- a/pdfshrinker.py
+++ b/pdfshrinker.py
@@ -11,20 +11,30 @@ elif which('gs') is not None: gs = 'gs' # Other
 else: sys.exit('Error: Could not find GhostScript!')
 
 def shrink_file(root, filename):
-	f, e = os.path.splitext(filename) 
+	f, e = os.path.splitext(filename)
 	if e == '.pdf':
 		path = os.path.join(root, filename)
 		npath = os.path.join(root, f + '_shrink' + e)
-		
+
 		run([gs, '-q', '-dNOPAUSE', '-dBATCH', '-sDEVICE=pdfwrite', '-dPDFSETTINGS=/ebook' ,'-sOutputFile=' + npath, path])
 		if os.path.isfile(npath):
-			if os.path.getsize(npath) < os.path.getsize(path):
+			size_pre = os.path.getsize(path) # File size before shrinking
+			size_post = os.path.getsize(npath) # File size after shrinking
+
+			reduce_rate, reduce_bytes = (0.0, 0)
+
+			if size_post < size_pre:
 				# The new file is smaller than the existing one; keep it
 				os.remove(path)
 				os.rename(npath, path)
+
+				reduce_rate = 1.0 - size_post / size_pre
+				reduce_bytes = size_pre - size_post
 			else:
 				# The new file is larger than the existing one; delete it
 				os.remove(npath)
+
+			print("shrink_file: {:.2f} % -- {} ({:,} bytes)".format(-reduce_rate * 100, path, -reduce_bytes))
 
 if os.path.isfile(walkpath):
 	root, filename = os.path.split(walkpath)


### PR DESCRIPTION
When using `pdfshrinker.py` I realised there was no output at all. Because of this I was unable to know if the files I specified were actually being processed and had to manually check if their filesize changed at all.

In order to fix this, I thought about adding some logging to print what file is being processed as well as the filesize reduction in bytes and percentage. Whenever a file did not shrink, it will display a reduction of `0 bytes` and a percentage of `-0.00 %`.

Here is how it looks like!

![Example](https://user-images.githubusercontent.com/49949198/126772196-757ce871-9565-44ba-90eb-970a696513a5.png)

Thank you in advance for reviewing my pull request and I hope you will find my idea helpful!
