### PR TITLE
pdfshrinker multiprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,26 @@ Past subjects and other files, for the benefit of EPITA students.
 
 Visit the website: [past-exams.epidocs.eu](https://past-exams.epidocs.eu/)
 
-
 ## Contributing
 
 To contribute, you can fork this project, add files and then open a pull request.
 
 ### Compress your files!
 
-When adding files, using the `pdfshrink.py' script to compress them.
+When adding files, please use the `pdfshrinker.py` script at the root of this repository to compress them!
 
-The script is made to be run on Linux, and it requires Python 3.5+.
+The script is made to be run on any OS. It requires Python 3.5+ and [GhostScript](https://www.ghostscript.com/).
 
-Usage: `pdfshrink.py [path]`
+Usage: `pdfshrinker [-h] [--threads count] [path [path ...]]`
 
-The optional `path` parameter can be:
-- The path to the pdf file to compress.
-- The path to a folder to search pdf files in.
-If omitted, the script will search for pdfs in the current folder and its sub-folders.
+The optional `path` argument can be either paths to one or many PDF files and/or directories to search PDF files in.
+If omitted, the script will search for PDFs in the current folder and its sub-directories.
 
+You can set the number of threads using the `--threads` or `-X` optional argument. Default is 2.
+
+Example: `python3 pdfshrinker.py -X 4 ./S3/MCQs`
+
+In this example, the script will use 4 threads to shrink the PDF files of the `S3/MCQs` directory and its sub-directories.
 
 ## Continuous Integration builds
 
@@ -31,4 +33,4 @@ Powered by Travis CI.
 
 At every push to `master`, the PHP script `deploy.php` is executed to generate the website infos and deploy the result to `gh-pages`.
 
-- "/_assets/" content is moved to the root directory at the end of the script
+- `/_assets/` content is moved to the root directory at the end of the script.

--- a/pdfshrinker.py
+++ b/pdfshrinker.py
@@ -15,7 +15,7 @@ gs_exec = "gs"
 
 def get_gs_exec() -> Optional[str]:
 	"""
-		Resolves the executable name of GhostScript
+		Resolves the name of the GhostScript executable
 
 		:return: the executable name of GhostScript or None if it was not found
 	"""
@@ -51,7 +51,7 @@ def collect_pdfs(roots: List[str]) -> Set[str]:
 		directories and their sub-directories
 
 		:param roots: the paths to the root directories
-		:return: a set containing every PDF filenames
+		:return: a set containing the filenames of every PDF file
 	"""
 
 	pdfs = set()
@@ -68,10 +68,10 @@ def collect_pdfs(roots: List[str]) -> Set[str]:
 
 def shrink_file(filename: str) -> Tuple[str, float, float]:
 	"""
-		Shrinks a PDF file using GhostScript and prints out
-		the result of the shrinking on the standard output
+		Shrinks a PDF file using GhostScript
 
 		:param filename: the filename of the PDF file
+        :return: the result in terms of filesize reduction
 	"""
 
 	global gs_exec
@@ -91,13 +91,13 @@ def shrink_file(filename: str) -> Tuple[str, float, float]:
 		filename
 	], check=True, stdout=DEVNULL)
 
-	# File size before shrinking
+	# Filesize before shrinking
 	size_pre = os.path.getsize(filename)
 
-	# File size after shrinking
+	# Filesize after shrinking
 	size_post = os.path.getsize(filename_gs_out)
 
-	# File size reduction in percentage and raw byte count
+	# Filesize reduction in percentage and raw byte count
 	reduce_rate, reduce_byte_count = (0.0, 0)
 
 	if size_post < size_pre:
@@ -117,9 +117,9 @@ def shrink_files(pdfs: Set[str], thread_count: int) -> List[Tuple[str, float, fl
 	"""
 		Shrinks a collection of PDF files
 
-		:param pdfs: the set of PDF file filenames
+		:param pdfs: a set containing the filenames of the PDF files to shrink
 		:param thread_count: number of processes to use
-		:return: the results of the shrinking for each file
+		:return: the results (in terms of filesize reduction) for each file
 	"""
 
 	results = []

--- a/pdfshrinker.py
+++ b/pdfshrinker.py
@@ -1,47 +1,138 @@
-#!/usr/bin/env python3 
+#!/usr/bin/env python3
 
-import os
-from sys import argv
+from argparse import ArgumentParser
+from multiprocessing import Pool
 from shutil import which
-from subprocess import run
+from subprocess import run, DEVNULL
+from typing import List, Optional, Set
+import os
+import sys
 
-walkpath = argv[1] if len(argv) >= 2 else '.'
+DEFAULT_THREAD_COUNT = 2
 
-if which('gswin64c') is not None: gs = 'gswin64c' # Windows 64-bit
-elif which('gswin32c') is not None: gs = 'gswin32c' # Windows 32-bit
-elif which('gs') is not None: gs = 'gs' # Other
-else: sys.exit('Error: Could not find GhostScript!')
+# GhostScript executable name
+gs_exec = "gs"
 
-def shrink_file(root, filename):
-	f, e = os.path.splitext(filename)
-	if e == '.pdf':
-		path = os.path.join(root, filename)
-		npath = os.path.join(root, f + '_shrink' + e)
+def get_gs_exec() -> Optional[str]:
+	"""
+		Resolves the executable name of GhostScript
 
-		run([gs, '-q', '-dNOPAUSE', '-dBATCH', '-sDEVICE=pdfwrite', '-dPDFSETTINGS=/ebook' ,'-sOutputFile=' + npath, path])
-		if os.path.isfile(npath):
-			size_pre = os.path.getsize(path) # File size before shrinking
-			size_post = os.path.getsize(npath) # File size after shrinking
+		:return: the executable name of GhostScript or None if it was not found
+	"""
 
-			reduce_rate, reduce_bytes = (0.0, 0)
+	# Possible GhostScript executable names
+	executable_names = [
+		'gswin64c', # Windows 64-bit
+		'gswin32c', # Windows 32-bit
+		'gs'        # Other
+	]
 
-			if size_post < size_pre:
-				# The new file is smaller than the existing one; keep it
-				os.remove(path)
-				os.rename(npath, path)
+	# Search for the executable
+	for exec_name in executable_names:
+		if which(exec_name) is not None:
+			return exec_name
 
-				reduce_rate = 1.0 - size_post / size_pre
-				reduce_bytes = size_pre - size_post
-			else:
-				# The new file is larger than the existing one; delete it
-				os.remove(npath)
+	return None
 
-			print("shrink_file: {:.2f} % -- {} ({:,} bytes)".format(-reduce_rate * 100, path, -reduce_bytes))
+def is_pdf(filename: str) -> bool:
+	"""
+		Determines if a filename has a PDF extension
 
-if os.path.isfile(walkpath):
-	root, filename = os.path.split(walkpath)
-	shrink_file(root, filename)
-else:
-	for root, dirs, files in os.walk(walkpath, topdown=False):
-		for filename in files:
-			shrink_file(root, filename)
+		:param filename: the filename
+		:return: True if the filename has a '.pdf' extension
+	"""
+
+	extension = os.path.splitext(filename)[1]
+	return extension == '.pdf'
+
+def collect_pdfs(roots: List[str]) -> Set[str]:
+	"""
+		Collects the PDF files of many root
+		directories and their sub-directories
+
+		:param roots: the paths to the root directories
+		:return: a set containing every PDF filenames
+	"""
+
+	pdfs = set()
+
+	for root in roots:
+		for root, dirs, files in os.walk(root):
+			for file in files:
+				if is_pdf(file):
+					pdfs.add(os.path.join(root, file))
+
+			pdfs.union(collect_pdfs(dirs))
+
+	return pdfs
+
+def shrink_file(filename: str):
+	"""
+		Shrinks a PDF file using GhostScript and prints out
+		the result of the shrinking on the standard output
+
+		:param filename: the filename of the PDF file
+	"""
+
+	global gs_exec
+
+	# Temporary filename for the GhostScript output
+	filename_gs_out = filename + '.gs'
+
+	# Run GhostScript on the PDF file
+	status = run([
+		gs_exec,
+		'-q',
+		'-dNOPAUSE',
+		'-dBATCH',
+		'-sDEVICE=pdfwrite',
+		'-dPDFSETTINGS=/ebook',
+		'-sOutputFile=' + filename_gs_out,
+		filename
+	], stdout=DEVNULL)
+
+	if status.returncode == 0:
+		# File size before shrinking
+		size_pre = os.path.getsize(filename)
+
+		# File size after shrinking
+		size_post = os.path.getsize(filename_gs_out)
+
+		# File size reduction in percentage and raw byte count
+		reduce_rate, reduce_byte_count = (0.0, 0)
+
+		if size_post < size_pre:
+			# The new file is smaller than the existing one; keep it
+			os.remove(filename)
+			os.rename(filename_gs_out, filename)
+
+			reduce_rate = 1.0 - size_post / size_pre
+			reduce_byte_count = size_pre - size_post
+		else:
+			# The new file is larger than the existing one; delete it
+			os.remove(filename_gs_out)
+
+		print("shrink_file: {:.2f} % -- {} ({:,} bytes)".format(-reduce_rate * 100, filename, -reduce_byte_count))
+	else:
+		print("shrink_file: {}: return code {} for {}".format(gs_exec, status.returncode, filename), file=sys.stderr)
+
+def main():
+	global gs_exec
+	gs_exec = get_gs_exec()
+
+	if gs_exec is not None:
+		parser = ArgumentParser("pdfshrinker")
+		parser.add_argument("path", type=str, nargs='*', default=['.'], help="Target files and directories")
+		parser.add_argument("--threads", "-X", type=int, default=DEFAULT_THREAD_COUNT, metavar="count", help="Number of threads")
+
+		args = parser.parse_args()
+
+		pdfs = collect_pdfs(args.path)
+
+		with Pool(args.threads) as pool:
+			pool.map(shrink_file, pdfs)
+	else:
+		sys.exit("Error: unable to find GhostScript executable in PATH")
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
I have thought about adding multiprocessing capabilities to the PDF shrinker script for some time now and it is done!

I used the `multiprocessing` module to have true parallelization since the `multithreading` module is restricted by the GIL.

I added an argument parser using the `argparse` module in order to have a thread count argument as well as a nice looking usage and help page.

```
usage: pdfshrinker [-h] [--threads count] [path [path ...]]

positional arguments:
  path                  Target files and directories

optional arguments:
  -h, --help            show this help message and exit
  --threads count, -X count
                        Number of threads
```

The behaviour of the script does not change except :
+ it now supports this `--threads` or `-X` optional argument, specifying the number of threads (or in our case, processes really)
+ it now prints out the results after the execution is complete

Hope this helps!