### PR TITLE
Escape ampersand characters in paths

### DIFF
--- a/build.php
+++ b/build.php
@@ -96,7 +96,7 @@ function getMetaInfos($pathList)
 				isset($metaJSONs[$dir]['folder']['description']) ? $metaJSONs[$dir]['folder']['description'] : '',
 				'- Home' . "\n" . '- ' . implode("\n" . '- ', $breadcrumb),
 				file_exists($dir . '/README.md') ? '{% include_relative README.md %}' : '',
-				str_replace([' ', '#'], ['_', 's'], strtolower(implode('.', $breadcrumb))),
+				str_replace([' ', '#', '&'], ['_', 's', 'n'], strtolower(implode('.', $breadcrumb))),
 			];
 
 			// Save generated index file
@@ -185,7 +185,7 @@ function buildSubFolders($folders)
 		);
 
 		// Make new folders
-		$lowercaseFolder = str_replace([' ', '#'], ['_', 's'], strtolower($folder));
+		$lowercaseFolder = str_replace([' ', '#', '&'], ['_', 's', 'n'], strtolower($folder));
 		if (!file_exists('_data/' . $lowercaseFolder . '/'))
 		{
 			mkdir('_data/' . $lowercaseFolder . '/');


### PR DESCRIPTION
This PR fixes `build.php` to escape ampersands ("&") in paths.

This is related to #153 and a follow-up on #154.
